### PR TITLE
Exclude JSR310 types from animal sniffer checks

### DIFF
--- a/querydsl-root/pom.xml
+++ b/querydsl-root/pom.xml
@@ -45,6 +45,7 @@
     <cglib.version>2.2.2</cglib.version>    
     <findbugs.version>1.3.2</findbugs.version>
     <slf4j.version>1.6.1</slf4j.version>
+    <animal-sniffer.version>1.13</animal-sniffer.version>
     
     <!-- Import-Package definitions for maven-bundle-plugin -->
     <osgi.import.package.root>
@@ -85,6 +86,12 @@
       <artifactId>reflections</artifactId>
       <version>0.9.9</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-annotations</artifactId>
+        <version>${animal-sniffer.version}</version>
+        <optional>true</optional>
     </dependency>
   </dependencies>
 
@@ -373,7 +380,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.13</version>
+        <version>${animal-sniffer.version}</version>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/AbstractJSR310DateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/AbstractJSR310DateTimeType.java
@@ -1,9 +1,10 @@
 package com.querydsl.sql.types;
 
-
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.TimeZone;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * Common abstract superclass for Type implementations for Java Time API (JSR310)
@@ -12,6 +13,7 @@ import java.util.TimeZone;
  *
  * @param <T>
  */
+@IgnoreJRERequirement //conditionally included
 public abstract  class AbstractJSR310DateTimeType<T> extends AbstractType<T> {
 
     private static final Calendar UTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"));

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310InstantType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310InstantType.java
@@ -1,14 +1,18 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
 import java.sql.*;
 import java.time.Instant;
+
+import javax.annotation.Nullable;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * JSR310InstantType maps java.time.Instant to Date on the JDBC level
  *
  * @author Artur Chyży <artur.chyzy@gmail.com>
  */
+@IgnoreJRERequirement //conditionally included
 public class JSR310InstantType extends AbstractJSR310DateTimeType<Instant>  {
 
     public JSR310InstantType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
@@ -1,15 +1,19 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+
+import javax.annotation.Nullable;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * JSR310LocalDateTimeType maps java.time.LocalDateTime to Date on the JDBC level
  *
  * @author Artur Chyży <artur.chyzy@gmail.com>
  */
+@IgnoreJRERequirement //conditionally included
 public class JSR310LocalDateTimeType extends AbstractJSR310DateTimeType<LocalDateTime> {
 
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
@@ -1,14 +1,18 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
 import java.sql.*;
 import java.time.LocalDate;
+
+import javax.annotation.Nullable;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * JSR310LocalDateType maps java.time.LocalDate to Date on the JDBC level
  *
  * @author Artur Chyży <artur.chyzy@gmail.com>
  */
+@IgnoreJRERequirement //conditionally included
 public class JSR310LocalDateType extends AbstractJSR310DateTimeType<LocalDate> {
 
     public JSR310LocalDateType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalTimeType.java
@@ -1,14 +1,18 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
 import java.sql.*;
 import java.time.LocalTime;
+
+import javax.annotation.Nullable;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * JSR310LocalTimeType maps java.time.LocalTime to Date on the JDBC level
  *
  * @author Artur Chyży <artur.chyzy@gmail.com>
  */
+@IgnoreJRERequirement //conditionally included
 public class JSR310LocalTimeType extends AbstractJSR310DateTimeType<LocalTime> {
 
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
@@ -1,14 +1,18 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
 import java.sql.*;
 import java.time.OffsetDateTime;
+
+import javax.annotation.Nullable;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * JSR310OffsetDateTimeType maps java.time.OffsetDateTime to Date on the JDBC level
  *
  * @author Artur Chyży <artur.chyzy@gmail.com>
  */
+@IgnoreJRERequirement //conditionally included
 public class JSR310OffsetDateTimeType extends AbstractJSR310DateTimeType<OffsetDateTime> {
 
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetTimeType.java
@@ -1,14 +1,18 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
 import java.sql.*;
 import java.time.OffsetTime;
+
+import javax.annotation.Nullable;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * JSR310OffsetTimeType maps java.time.OffsetTime to Date on the JDBC level
  *
  * @author Artur Chyży <artur.chyzy@gmail.com>
  */
+@IgnoreJRERequirement //conditionally included
 public class JSR310OffsetTimeType extends AbstractJSR310DateTimeType<OffsetTime> {
 
     public JSR310OffsetTimeType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
@@ -1,14 +1,18 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
 import java.sql.*;
 import java.time.ZonedDateTime;
+
+import javax.annotation.Nullable;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * JSR310ZonedDateTimeType maps java.time.ZonedDateTime to Date on the JDBC level
  *
  * @author Artur Chyży <artur.chyzy@gmail.com>
  */
+@IgnoreJRERequirement //conditionally included
 public class JSR310ZonedDateTimeType extends AbstractJSR310DateTimeType<ZonedDateTime> {
 
 


### PR DESCRIPTION
This can be merged back for continuity's sake.
